### PR TITLE
Fixed /back not teleporting you to another server when having backed …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>dev.masa</groupId>
             <artifactId>MaSuiteCore</artifactId>
-            <version>2.0.0-20200501.110525-24</version>
+            <version>2.0.0-20200514.135609-28</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/dev/masa/masuiteteleports/bungee/listeners/TeleportMessageListener.java
+++ b/src/main/java/dev/masa/masuiteteleports/bungee/listeners/TeleportMessageListener.java
@@ -194,8 +194,11 @@ public class TeleportMessageListener implements Listener {
             if (loc != null) {
                 plugin.getPlayerPositionService().requestPosition(sender);
                 if (!loc.getServer().equals(sender.getServer().getInfo().getName())) {
+                    String server = sender.getServer().getInfo().getName();
                     sender.connect(plugin.getProxy().getServerInfo(loc.getServer()));
-                    plugin.getProxy().getScheduler().schedule(plugin, () -> tpforce.tp(sender, sender.getName(), loc), plugin.config.load(null, "config.yml").getInt("teleportation-delay"), TimeUnit.MILLISECONDS);
+                    loc.setServer(server);
+                    plugin.getApi().getPlayerService().getPlayer(sender.getUniqueId()).setLocation(loc);
+
                 } else {
                     tpforce.tp(sender, sender.getName(), loc);
                 }


### PR DESCRIPTION
…from another Server before.

When you used /back to return from ServerA to ServerB and the used it again on ServerB, you've ended up on the same server where your back destination was instead of getting send back to ServerA. I removed the unnecessary bukkit tp line in case of Server switching since in case of /back you dont need to be teleportet on Bukkit side when backing to another Server